### PR TITLE
MRG: fix error with abund queries x abund subjects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sourmash_plugin_containment_search"
 description = "sourmash plugin for improved output of containment search for metagenomes"
 readme = "README.md"
 requires-python = ">=3.8"
-version = "0.4.1"
+version = "0.4.2"
 
 dependencies = ["sourmash>=4.8.0,<5", "numpy"]
 

--- a/tests/test_sourmash_plugin.py
+++ b/tests/test_sourmash_plugin.py
@@ -41,6 +41,29 @@ def test_0_x_podar(runtmp):
     assert "100.0%    54.2       3.1%     SRR606249" in out
 
 
+def test_podar_x_0_flatten_query(runtmp):
+    query = utils.get_test_data('SRR606249.k31.sig.zip')
+    against = utils.get_test_data('0.sig.zip')
+    runtmp.sourmash('scripts', 'mgsearch', query, against)
+
+    out = runtmp.last_result.out
+    print(out)
+    assert 0
+
+
+def test_mgsearch_podar_x_0_flatten_query(runtmp):
+    query = utils.get_test_data('SRR606249.k31.sig.zip')
+    against = utils.get_test_data('0.sig.zip')
+    runtmp.sourmash('scripts', 'mgmanysearch', '--queries', query,
+                    '--against', against)
+
+    out = runtmp.last_result.out
+    print(out)
+    err = runtmp.last_result.err
+    print(err)
+    assert 0
+
+
 def test_0_x_podar_out(runtmp):
     query = utils.get_test_data('0.sig.zip')
     against = utils.get_test_data('SRR606249.k31.sig.zip')

--- a/tests/test_sourmash_plugin.py
+++ b/tests/test_sourmash_plugin.py
@@ -48,7 +48,16 @@ def test_podar_x_0_flatten_query(runtmp):
 
     out = runtmp.last_result.out
     print(out)
-    assert 0
+    assert "1.0%     N/A        N/A     CP001472.1 " in out
+
+
+def test_podar_x_podar_flatten_query(runtmp):
+    query = utils.get_test_data('SRR606249.k31.sig.zip')
+    runtmp.sourmash('scripts', 'mgsearch', query, query)
+
+    out = runtmp.last_result.out
+    print(out)
+    assert "100.0%    17.5     100.0%     SRR606249" in out
 
 
 def test_mgsearch_podar_x_0_flatten_query(runtmp):
@@ -61,7 +70,20 @@ def test_mgsearch_podar_x_0_flatten_query(runtmp):
     print(out)
     err = runtmp.last_result.err
     print(err)
-    assert 0
+
+    assert 'SRR606249            1.0%     N/A        N/A     CP001472.1' in out
+
+
+def test_mgsearch_podar_x_podar_flatten_query(runtmp):
+    query = utils.get_test_data('SRR606249.k31.sig.zip')
+    runtmp.sourmash('scripts', 'mgmanysearch', '--queries', query,
+                    '--against', query)
+
+    out = runtmp.last_result.out
+    print(out)
+    err = runtmp.last_result.err
+    print(err)
+    assert "SRR606249          100.0%    17.5     100.0%     SRR606249" in out
 
 
 def test_0_x_podar_out(runtmp):


### PR DESCRIPTION
Fixes tricky error that occurred only when query AND against both had `track_abundance=True`.

Fixes https://github.com/sourmash-bio/sourmash_plugin_containment_search/issues/13